### PR TITLE
Fix "Tenant does not have an SPO license"

### DIFF
--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -80,7 +80,7 @@ class OneDriveClient {
     }
 
     getAccountId() {
-        return this.request('https://graph.microsoft.com/v1.0/me/drive/')
+        return this.request('https://graph.microsoft.com/v1.0/me')
         .catch(logErrorAndReject('Non-200 while trying to query user details', this.logger))
         .then(({ data }) => {
             return data.id;

--- a/src/util.js
+++ b/src/util.js
@@ -4,7 +4,7 @@ const logErrorAndReject = (text, logger) => {
     return error => {
         if ('response' in error) {
             const { response } = error;
-            logger.error(text, _.pick(response, ['status', 'data', 'config']));
+            logger.error(text, _.pick(response, ['status', 'data', 'config.url']));
             return Promise.reject(new Error(text));
         }
         logger.error('Unexpected error', { err: error });
@@ -14,6 +14,8 @@ const logErrorAndReject = (text, logger) => {
 
 const DEFAULT_SCOPES = [
     'offline_access',
+    'openid',
+    'user.read',
     'files.readwrite'
 ];
 


### PR DESCRIPTION
I'm not exactly sure what was causing the problem, because the error
message has to do with the user not having an Office 365 license,
but after digging around a bit with the Microsoft API explorer, it seems
we can get the account id from the /me endpoint as well, so I'm using
that now, and it seems to work