### PR TITLE
#35-2 expand unshareFrom to work with both: email & permissionId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive",
-  "version": "2.6.1",
+  "version": "2.6.3",
   "main": "src/index.js",
   "repository": "git@github.com:correlateteam/onedrive.git",
   "author": "Norbert Kéri <norbert@correlate.com>",

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -10,9 +10,10 @@ const {
 } = require("./util");
 
 const ROOT_URL = 'https://graph.microsoft.com/v1.0'
-const PERMISSION_TYPES = {
-    'USER': 'user',
-    'ANYONE': 'anyone',
+
+const SHARING_IDENTIFICATOR = {
+    EMAIL: 'email',
+    PERMISSION: 'permission',
 };
 
 class OneDriveClient {
@@ -49,11 +50,25 @@ class OneDriveClient {
         .catch(logErrorAndReject('Non-200 while trying to share file', this.logger));
     }
 
-    unshareFrom(fileId, driveId, permissionId) {
+    /**
+     * Unshares file for other user(s) by identificator
+     * @async
+     *
+     * @param {string} fileId File ID
+     * @param {string} driveId Drive ID
+     * @param {object} identificator Identificator of sharing
+     * @param {string} identificator.value Identificator value
+     * @param {string} identificator.type Identificator type: 'email', 'permission'
+     */
+    unshareFrom(fileId, driveId, identificator) {
         const permissionUrl = `${ROOT_URL}/drives/${driveId}/items/${fileId}/permissions`;
 
-        return this.graphApi.request(`${permissionUrl}/${permissionId}`, "DELETE")
-            .catch(logErrorAndReject('Non-200 while removing permission', this.logger));
+        switch (identificator.type) {
+            case SHARING_IDENTIFICATOR.EMAIL:
+                return this._unshareByEmail(permissionUrl, identificator.value);
+            case SHARING_IDENTIFICATOR.PERMISSION:
+                return this._unshareByPermission(permissionUrl, identificator.value);
+        }
     }
 
     getAccountId() {
@@ -252,6 +267,40 @@ class OneDriveClient {
             .catch(logErrorAndReject(`Non-200 while trying to delete subscription ${subscriptionId}`, this.logger));
     }
 
+    /**
+     * Unshares file by user's email
+     * @async
+     *
+     * @param {string} permissionUrl Permissions endpoint, which can be continued depending on next action
+     * @param {string} email User's email
+     */
+    _unshareByEmail(permissionUrl, email) {
+        return this.graphApi.request(permissionUrl)
+            .catch(logErrorAndReject('Non-200 while trying to list permissions on file', this.logger))
+            .then(data => {
+                const permission = data.value.find(d => _.get(d, 'invitation.email') === email);
+                if (permission) {
+                    return this._unshareByPermission(permissionUrl, permission.id)
+                        .then(() => {});
+                }
+                this.logger.error("Could not revoke permission from file", { fileId, email });
+                return Promise.reject(new Error("Could not revoke permission from file"));
+            });
+    }
+
+    /**
+     * Unshares file by permission ID.
+     * E.g., public link (for any user) you can unshare only by permissionId
+     * @async
+     *
+     * @param {string} permissionUrl Permissions endpoint, which can be continued depending on next action
+     * @param {string} permissionId Permission ID
+     */
+    _unshareByPermission(permissionUrl, permissionId) {
+        return this.graphApi.request(`${permissionUrl}/${permissionId}`, "DELETE")
+            .catch(logErrorAndReject('Non-200 while removing permission', this.logger));
+    }
+    
 }
 
 module.exports = OneDriveClient;


### PR DESCRIPTION
Task #35

Now we can unshare with `permissionId` and, if it is early shared file, which has no stored permission id, we can unshare it with `email`.