### PR TITLE
#48-3 add new methods for sharepoint to get file and public url by file

### DIFF
--- a/src/baseDriveClient.js
+++ b/src/baseDriveClient.js
@@ -1,0 +1,45 @@
+const GraphClient = require("./graphClient.js");
+const {
+    logErrorAndReject,
+} = require("./util");
+
+/**
+ * @typedef BaseDriveClient Base methods to work with Microsoft files
+ */
+class BaseDriveClient extends GraphClient {
+    /**
+     * @param {GraphAPI} graphApi
+     * @param {object} [logger=console] Logs handler
+     */
+    constructor(graphApi, logger) {
+        super(graphApi, logger);
+    }
+
+    getFileById(endpoint) {
+        return this.graphApi
+            .request(endpoint)
+            .catch(
+                logErrorAndReject(`Non-200 while querying file ${endpoint}`, this.logger)
+            )
+            .then((data) => {
+                return {
+                    name: data.name,
+                    webUrl: data.webUrl,
+                    packageType: data.package ? data.package.type : "",
+                    parentReference: {
+                        path: data.parentReference.path,
+                    },
+                };
+            });
+    }
+
+    getPreview(endpoint) {
+        return this.graphApi.request(endpoint)
+            .catch(logErrorAndReject(`Non-200 while querying file ${endpoint}`, this.logger))
+            .then(data => {
+                return  data.value;
+            });
+    }
+}
+
+module.exports = BaseDriveClient;

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -8,14 +8,15 @@ const {
     validateAndDefaultTo,
     getParamValue,
 } = require("./util");
+const BaseDriveClient = require('./baseDriveClient');
+
 
 const ROOT_URL = 'https://graph.microsoft.com/v1.0';
 const rootFolderId = 'root';
-class OneDriveClient {
+class OneDriveClient extends BaseDriveClient {
 
     constructor(graphApi, logger) {
-        this.graphApi = graphApi;
-        this.logger = logger;
+        super(graphApi, logger);
     }
 
     shareTo(fileId, driveId, email) {
@@ -90,18 +91,7 @@ class OneDriveClient {
 
     getFileById(fileId) {
         this.logger.info('Getting OneDrive file', { fileId });
-        return this.graphApi.request(`https://graph.microsoft.com/v1.0/me/drive/items/${fileId}`)
-        .catch(logErrorAndReject(`Non-200 while querying file ${fileId}`, this.logger))
-        .then(data => {
-            return {
-                name: data.name,
-                webUrl: data.webUrl,
-                packageType: data.package ? data.package.type : '',
-                parentReference: {
-                    path: data.parentReference.path,
-                },
-            }
-        });
+        return super.getFileById(`${this.ROOT_URL}/me/drive/items/${fileId}`);
     }
 
     getPublicUrl(fileId) {
@@ -109,13 +99,9 @@ class OneDriveClient {
             .then(file => file.webUrl);
     }
 
-    getPreview(fileId) {
+    getPreview(_driveId, fileId) {
         this.logger.info('Getting OneDrive file preview', { fileId });
-        return this.graphApi.request(`https://graph.microsoft.com/v1.0/me/drive/items/${fileId}/thumbnails`)
-            .catch(logErrorAndReject(`Non-200 while querying file ${fileId}`, this.logger))
-            .then(data => {
-                return  data.value;
-            });
+        return super.getPreview(`${this.ROOT_URL}/me/drive/items/${fileId}/thumbnails`);
     }
 
     createFolder(folderName, parentId = rootFolderId, autorename = true) {

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -99,7 +99,7 @@ class OneDriveClient extends BaseDriveClient {
             .then(file => file.webUrl);
     }
 
-    getPreview(_driveId, fileId) {
+    getPreview(fileId) {
         this.logger.info('Getting OneDrive file preview', { fileId });
         return super.getPreview(`${this.ROOT_URL}/me/drive/items/${fileId}/thumbnails`);
     }

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -1,22 +1,20 @@
-const { addDays } = require('date-fns');
 const _ = require('lodash');
 const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18 
 const {
     logErrorAndReject,
     formatDriveResponse,
 } = require("./util");
+const BaseDriveClient = require('./baseDriveClient');
 
 const ROOT_URL = 'https://graph.microsoft.com/v1.0'
 const rootFolderId = 'root';
 const SYSTEM_SITES = ['appcatalog'];
 
-// TODO: create base class for sharepoint and onedrive
 
-class SharepointClient {
+class SharepointClient extends BaseDriveClient {
 
     constructor(graphApi, logger) {
-        this.graphApi = graphApi;
-        this.logger = logger;
+        super(graphApi, logger);
     }
 
     getAccountInfo(fields = []) {
@@ -42,10 +40,8 @@ class SharepointClient {
     getPreview(siteId, fileId) {
         siteId = siteId || rootFolderId;
         
-        this.logger.info('Getting Sharepoint file preview', { fileId });
-        return this.graphApi.request(`${ROOT_URL}/sites/${siteId}/drive/items/${fileId}/thumbnails`)
-            .catch(logErrorAndReject(`Non-200 while querying file ${fileId}`, this.logger))
-            .then(data => data.value);
+        this.logger.info('Getting Sharepoint file preview', { siteId, fileId });
+        return super.getPreview(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/thumbnails`);
     }
 
     getSites() {
@@ -58,6 +54,18 @@ class SharepointClient {
                 value: response.value.filter(v => !SYSTEM_SITES.includes(v.name)),
             }))
             .then(formatDriveResponse);
+    }
+
+    getFileById(siteId, fileId) {
+        siteId = siteId || rootFolderId;
+
+        this.logger.info(`Getting Sharepoint file`, { siteId, fileId });
+        return super.getFileById(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}`);
+    }
+
+    getPublicUrl(siteId, fileId) {
+        return this.getFileById(siteId, fileId)
+            .then(file => file.webUrl);
     }
 }
 

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -56,15 +56,15 @@ class SharepointClient extends BaseDriveClient {
             .then(formatDriveResponse);
     }
 
-    getFileById(siteId, fileId) {
+    getFileById(fileId, siteId) {
         siteId = siteId || rootFolderId;
 
         this.logger.info(`Getting Sharepoint file`, { siteId, fileId });
         return super.getFileById(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}`);
     }
 
-    getPublicUrl(siteId, fileId) {
-        return this.getFileById(siteId, fileId)
+    getPublicUrl(fileId, siteId) {
+        return this.getFileById(fileId, siteId)
             .then(file => file.webUrl);
     }
 }


### PR DESCRIPTION
### Merge after PR #50 

Changes:
- new sharepoint methods: `getFileById`, `getPublicUrl`;
- add new base class for drives to avoid code duplicates of `getFileById` and `getPreview`