### PR TITLE
#48-4 extensions for file adding of main process

### DIFF
--- a/src/baseDriveClient.js
+++ b/src/baseDriveClient.js
@@ -1,3 +1,4 @@
+const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18 
 const GraphClient = require("./graphClient.js");
 const {
     logErrorAndReject,
@@ -15,28 +16,72 @@ class BaseDriveClient extends GraphClient {
         super(graphApi, logger);
     }
 
-    getFileById(endpoint) {
+    /**
+     * Gets drive item by its id
+     * @param {*} endpoint 
+     * @param {*} options 
+     * @returns {Promise<driveItem>} https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0#properties
+     * @async
+     */
+    getFileById(endpoint, options) {
+        this.logger.info(`Query options`, { options });
+        const queryOptions = this._generateQueryOptions(options);
+
         return this.graphApi
-            .request(endpoint)
+            .request(`${endpoint}?${queryOptions}`)
             .catch(
                 logErrorAndReject(`Non-200 while querying file ${endpoint}`, this.logger)
             )
             .then((data) => {
                 return {
-                    name: data.name,
-                    webUrl: data.webUrl,
+                    ...data,
                     packageType: data.package ? data.package.type : "",
-                    parentReference: data.parentReference,
                 };
             });
     }
 
+    /**
+     * Gets Preview data
+     * @param {string} endpoint Service specific endpoint
+     * @returns Preview data
+     * @async
+     */
     getPreview(endpoint) {
         return this.graphApi.request(endpoint)
             .catch(logErrorAndReject(`Non-200 while querying file ${endpoint}`, this.logger))
             .then(data => {
-                return  data.value;
+                return data.value;
             });
+    }
+
+    /**
+     * Generates valid Onedrive and Sharepoint query options
+     * https://learn.microsoft.com/en-us/graph/query-parameters
+     * @param {object} options
+     * @param {string[]} fields
+     * @param {string[]} expand Expand relations
+     * @returns {string}
+     */
+    _generateQueryOptions(options = {}) {
+        const { fields = [], expand = [] } = options;
+        let optionValid = [];
+
+        switch (true) {
+          /**
+           * Expand can affect `$select`, so it have to go first
+           */
+          case !!expand.length:
+            optionValid.push(
+              querystring.stringify({ $expand: expand.join(",") })
+            );
+          case !!fields.length:
+            // https://stackoverflow.com/a/44571731/13745132
+            optionValid.push(
+              querystring.stringify({ $select: [...fields, "id"].join(",") })
+            );
+        }
+
+        return optionValid.join("&");
     }
 }
 

--- a/src/baseDriveClient.js
+++ b/src/baseDriveClient.js
@@ -26,9 +26,7 @@ class BaseDriveClient extends GraphClient {
                     name: data.name,
                     webUrl: data.webUrl,
                     packageType: data.package ? data.package.type : "",
-                    parentReference: {
-                        path: data.parentReference.path,
-                    },
+                    parentReference: data.parentReference,
                 };
             });
     }

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -56,11 +56,11 @@ class SharepointClient extends BaseDriveClient {
             .then(formatDriveResponse);
     }
 
-    getFileById(fileId, siteId) {
+    getFileById(fileId, siteId, options) {
         siteId = siteId || rootFolderId;
 
         this.logger.info(`Getting Sharepoint file`, { siteId, fileId });
-        return super.getFileById(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}`);
+        return super.getFileById(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}`, options);
     }
 
     getPublicUrl(fileId, siteId) {


### PR DESCRIPTION
Merge after PRs #51, https://github.com/Correlate-AS/onedrive/pull/54 

Changes:
- add `options` param for `getFileById` sharepoint method;
- extend `getFileById` response.