### PR TITLE
specify concrete axios version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint": "^8.27.0"
   },
   "dependencies": {
-    "axios": "^1.1.3",
+    "axios": "1.1.3",
     "date-fns": "^2.29.3",
     "lodash": "^4.17.21"
   }


### PR DESCRIPTION
There were troubles for `yarn.lock` of https://github.com/Correlate-AS/backend 