### PR TITLE
#48-5 extensions for sharepoint files sharing

### DIFF
--- a/src/baseDriveClient.js
+++ b/src/baseDriveClient.js
@@ -54,6 +54,13 @@ class BaseDriveClient extends GraphClient {
             });
     }
 
+    /**
+     * Shares drive item for email
+     * @param {string} endpoint Service specific endpoint
+     * @param {string} email
+     * @returns {Promise}
+     * @async
+     */
     shareForEmail(endpoint, email) {
         return this.graphApi.request(endpoint, 'POST', {
                 requireSignin: true,
@@ -67,6 +74,12 @@ class BaseDriveClient extends GraphClient {
             .catch(logErrorAndReject('Non-200 while trying to share file', this.logger));
     }
 
+    /**
+     * Unshares drive item for email
+     * @param {string} endpoint Service specific endpoint
+     * @returns {Promise}
+     * @async
+     */
     unshareFrom(endpoint) {
         return this.graphApi.request(endpoint, "DELETE")
             .catch(logErrorAndReject('Non-200 while removing permission', this.logger));

--- a/src/baseDriveClient.js
+++ b/src/baseDriveClient.js
@@ -1,4 +1,4 @@
-const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18 
+const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18
 const GraphClient = require("./graphClient.js");
 const {
     logErrorAndReject,
@@ -18,8 +18,8 @@ class BaseDriveClient extends GraphClient {
 
     /**
      * Gets drive item by its id
-     * @param {*} endpoint 
-     * @param {*} options 
+     * @param {*} endpoint
+     * @param {*} options
      * @returns {Promise<driveItem>} https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0#properties
      * @async
      */
@@ -66,23 +66,21 @@ class BaseDriveClient extends GraphClient {
         const { fields = [], expand = [] } = options;
         let optionValid = [];
 
-        switch (true) {
-          /**
-           * Expand can affect `$select`, so it have to go first
-           */
-          case !!expand.length:
-            optionValid.push(
-              querystring.stringify({ $expand: expand.join(",") })
-            );
-          case !!fields.length:
-            // https://stackoverflow.com/a/44571731/13745132
-            optionValid.push(
-              querystring.stringify({ $select: [...fields, "id"].join(",") })
-            );
+        /**
+         * Expand can affect `$select`, so it have to go first
+         */
+        if (expand.length) {
+          optionValid.push(querystring.stringify({ $expand: expand.join(",") }));
+        }
+
+        if (fields.length) {
+          // https://stackoverflow.com/a/44571731/13745132
+          optionValid.push(querystring.stringify({ $select: [...fields, "id"].join(",") }) );
         }
 
         return optionValid.join("&");
     }
+
 }
 
 module.exports = BaseDriveClient;

--- a/src/baseDriveClient.js
+++ b/src/baseDriveClient.js
@@ -1,4 +1,4 @@
-const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18
+const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18 
 const GraphClient = require("./graphClient.js");
 const {
     logErrorAndReject,
@@ -18,8 +18,8 @@ class BaseDriveClient extends GraphClient {
 
     /**
      * Gets drive item by its id
-     * @param {*} endpoint
-     * @param {*} options
+     * @param {*} endpoint 
+     * @param {*} options 
      * @returns {Promise<driveItem>} https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0#properties
      * @async
      */
@@ -55,37 +55,6 @@ class BaseDriveClient extends GraphClient {
     }
 
     /**
-     * Shares drive item for email
-     * @param {string} endpoint Service specific endpoint
-     * @param {string} email
-     * @returns {Promise}
-     * @async
-     */
-    shareForEmail(endpoint, email) {
-        return this.graphApi.request(endpoint, 'POST', {
-                requireSignin: true,
-                sendInvitation: false,
-                roles: ["read"],
-                recipients: [{
-                    email,
-                }],
-                message: "File shared through Correlate"
-            })
-            .catch(logErrorAndReject('Non-200 while trying to share file', this.logger));
-    }
-
-    /**
-     * Unshares drive item for email
-     * @param {string} endpoint Service specific endpoint
-     * @returns {Promise}
-     * @async
-     */
-    unshareFrom(endpoint) {
-        return this.graphApi.request(endpoint, "DELETE")
-            .catch(logErrorAndReject('Non-200 while removing permission', this.logger));
-    }
-
-    /**
      * Generates valid Onedrive and Sharepoint query options
      * https://learn.microsoft.com/en-us/graph/query-parameters
      * @param {object} options
@@ -97,16 +66,19 @@ class BaseDriveClient extends GraphClient {
         const { fields = [], expand = [] } = options;
         let optionValid = [];
 
-        /**
-         * Expand can affect `$select`, so it have to go first
-         */
-        if (expand.length) {
-          optionValid.push(querystring.stringify({ $expand: expand.join(",") }));
-        }
-
-        if (fields.length) {
-          // https://stackoverflow.com/a/44571731/13745132
-          optionValid.push(querystring.stringify({ $select: [...fields, "id"].join(",") }) );
+        switch (true) {
+          /**
+           * Expand can affect `$select`, so it have to go first
+           */
+          case !!expand.length:
+            optionValid.push(
+              querystring.stringify({ $expand: expand.join(",") })
+            );
+          case !!fields.length:
+            // https://stackoverflow.com/a/44571731/13745132
+            optionValid.push(
+              querystring.stringify({ $select: [...fields, "id"].join(",") })
+            );
         }
 
         return optionValid.join("&");

--- a/src/graphClient.js
+++ b/src/graphClient.js
@@ -3,7 +3,7 @@
  */
  class GraphClient {
     /**
-     * @param {GraphAPI} graphApi
+     * @param {GraphAPI} graphApi 
      * @param {object} [logger=console] Logs handler
      */
   constructor(graphApi, logger) {

--- a/src/graphClient.js
+++ b/src/graphClient.js
@@ -3,7 +3,7 @@
  */
  class GraphClient {
     /**
-     * @param {GraphAPI} graphApi 
+     * @param {GraphAPI} graphApi
      * @param {object} [logger=console] Logs handler
      */
   constructor(graphApi, logger) {

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -26,16 +26,17 @@ class OneDriveClient extends BaseDriveClient {
             : this.shareForAnyone(fileId, driveId)
     }
 
-    /**
-     * Shares drive item for email
-     * @param {string} fileId Drive item ID
-     * @param {string} driveId Drive ID, which contains item
-     * @param {string} email Email, which share to
-     * @returns {Promise}
-     * @async
-     */
     shareForEmail(fileId, driveId, email) {
-        return super.shareForEmail(`${this.ROOT_URL}/drives/${driveId}/items/${fileId}/invite`, email);
+        return this.graphApi.request(`${ROOT_URL}/drives/${driveId}/items/${fileId}/invite`, 'POST', {
+            requireSignin: true,
+            sendInvitation: false,
+            roles: ["read"],
+            recipients: [{
+                email
+            }],
+            message: "File shared through Correlate"
+        })
+        .catch(logErrorAndReject('Non-200 while trying to share file', this.logger))
     }
 
     shareForAnyone(fileId, driveId) {
@@ -46,16 +47,11 @@ class OneDriveClient extends BaseDriveClient {
         .catch(logErrorAndReject('Non-200 while trying to share file', this.logger));
     }
 
-    /**
-     * Unshares drive item for email
-     * @param {string} fileId Drive item ID
-     * @param {string} driveId Drive ID, which contains item
-     * @param {string} permissionId Permission ID, which allows sharing
-     * @returns {Promise}
-     * @async
-     */
     unshareFrom(fileId, driveId, permissionId) {
-        return super.unshareFrom(`${ROOT_URL}/drives/${driveId}/items/${fileId}/permissions/${permissionId}`);
+        const permissionUrl = `${ROOT_URL}/drives/${driveId}/items/${fileId}/permissions`;
+
+        return this.graphApi.request(`${permissionUrl}/${permissionId}`, "DELETE")
+            .catch(logErrorAndReject('Non-200 while removing permission', this.logger));
     }
 
     getAccountId() {

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -26,6 +26,14 @@ class OneDriveClient extends BaseDriveClient {
             : this.shareForAnyone(fileId, driveId)
     }
 
+    /**
+     * Shares drive item for email
+     * @param {string} fileId Drive item ID
+     * @param {string} driveId Drive ID, which contains item
+     * @param {string} email Email, which share to
+     * @returns {Promise}
+     * @async
+     */
     shareForEmail(fileId, driveId, email) {
         return super.shareForEmail(`${this.ROOT_URL}/drives/${driveId}/items/${fileId}/invite`, email);
     }
@@ -38,6 +46,14 @@ class OneDriveClient extends BaseDriveClient {
         .catch(logErrorAndReject('Non-200 while trying to share file', this.logger));
     }
 
+    /**
+     * Unshares drive item for email
+     * @param {string} fileId Drive item ID
+     * @param {string} driveId Drive ID, which contains item
+     * @param {string} permissionId Permission ID, which allows sharing
+     * @returns {Promise}
+     * @async
+     */
     unshareFrom(fileId, driveId, permissionId) {
         return super.unshareFrom(`${ROOT_URL}/drives/${driveId}/items/${fileId}/permissions/${permissionId}`);
     }

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -27,16 +27,7 @@ class OneDriveClient extends BaseDriveClient {
     }
 
     shareForEmail(fileId, driveId, email) {
-        return this.graphApi.request(`${ROOT_URL}/drives/${driveId}/items/${fileId}/invite`, 'POST', {
-            requireSignin: true,
-            sendInvitation: false,
-            roles: ["read"],
-            recipients: [{
-                email
-            }],
-            message: "File shared through Correlate"
-        })
-        .catch(logErrorAndReject('Non-200 while trying to share file', this.logger))
+        return super.shareForEmail(`${this.ROOT_URL}/drives/${driveId}/items/${fileId}/invite`, email);
     }
 
     shareForAnyone(fileId, driveId) {
@@ -48,10 +39,7 @@ class OneDriveClient extends BaseDriveClient {
     }
 
     unshareFrom(fileId, driveId, permissionId) {
-        const permissionUrl = `${ROOT_URL}/drives/${driveId}/items/${fileId}/permissions`;
-
-        return this.graphApi.request(`${permissionUrl}/${permissionId}`, "DELETE")
-            .catch(logErrorAndReject('Non-200 while removing permission', this.logger));
+        return super.unshareFrom(`${ROOT_URL}/drives/${driveId}/items/${fileId}/permissions/${permissionId}`);
     }
 
     getAccountId() {

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -26,6 +26,14 @@ class OneDriveClient extends BaseDriveClient {
             : this.shareForAnyone(fileId, driveId)
     }
 
+    /**
+     * Shares drive item for email
+     * @param {string} fileId Drive item ID
+     * @param {string} driveId Drive ID, which contains item
+     * @param {string} email Email, which share to
+     * @returns {Promise}
+     * @async
+     */
     shareForEmail(fileId, driveId, email) {
         return this.graphApi.request(`${ROOT_URL}/drives/${driveId}/items/${fileId}/invite`, 'POST', {
             requireSignin: true,
@@ -47,6 +55,14 @@ class OneDriveClient extends BaseDriveClient {
         .catch(logErrorAndReject('Non-200 while trying to share file', this.logger));
     }
 
+    /**
+     * Unshares drive item for email
+     * @param {string} fileId Drive item ID
+     * @param {string} driveId Drive ID, which contains item
+     * @param {string} permissionId Permission ID, which allows sharing
+     * @returns {Promise}
+     * @async
+     */
     unshareFrom(fileId, driveId, permissionId) {
         const permissionUrl = `${ROOT_URL}/drives/${driveId}/items/${fileId}/permissions`;
 

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -59,15 +59,32 @@ class OneDriveClient extends BaseDriveClient {
      * Unshares drive item for email
      * @param {string} fileId Drive item ID
      * @param {string} driveId Drive ID, which contains item
-     * @param {string} permissionId Permission ID, which allows sharing
+     * @param {string} email Permission ID, which allows sharing
      * @returns {Promise}
      * @async
      */
-    unshareFrom(fileId, driveId, permissionId) {
+     unshareFrom(fileId, driveId, email) {
         const permissionUrl = `${ROOT_URL}/drives/${driveId}/items/${fileId}/permissions`;
+        return this.graphApi.request(permissionUrl)
+            .catch(logErrorAndReject('Non-200 while trying to list permissions on file', this.logger))
+            .then(data => {
+                const permission = data.value.find(d => {
+                    // unshare for public link
+                    if (!email) {
+                        return _.has(d, 'link.type') && !_.has(d, 'invitation');
+                    }
 
-        return this.graphApi.request(`${permissionUrl}/${permissionId}`, "DELETE")
-            .catch(logErrorAndReject('Non-200 while removing permission', this.logger));
+                    // unshare for email
+                    return d.invitation && d.invitation.email === email
+                })
+                if (permission) {
+                    return this.graphApi.request(`${permissionUrl}/${permission.id}`, "DELETE")
+                    .catch(logErrorAndReject('Non-200 while removing permission', this.logger))
+                    .then(() => {});
+                }
+                this.logger.error("Could not revoke permission from file", { fileId, email });
+                return Promise.reject(new Error("Could not revoke permission from file"));
+            });
     }
 
     getAccountId() {

--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -59,7 +59,7 @@ class OneDriveClient extends BaseDriveClient {
      * Unshares drive item for email
      * @param {string} fileId Drive item ID
      * @param {string} driveId Drive ID, which contains item
-     * @param {string} email Permission ID, which allows sharing
+     * @param {string} email
      * @returns {Promise}
      * @async
      */

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -64,8 +64,10 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getPublicUrl(fileId, siteId) {
-        return this.getFileById(fileId, siteId)
-            .then(file => file.webUrl);
+        this.logger.info(`Getting Sharepoint sharing link`, { siteId, fileId });
+
+        return this.createSharingLink(fileId, siteId)
+            .then(permission => permission.link.webUrl);
     }
 
     /**

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18 
+const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18
 const {
     logErrorAndReject,
     formatDriveResponse,
@@ -27,8 +27,8 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getFilesFrom(siteId, parentId, options = {}) {
-        parentId = parentId || rootFolderId;
-        siteId = siteId || rootFolderId;
+        parentId = this._validateContainer(parentId);
+        siteId = this._validateContainer(siteId);
 
         this.logger.info('Querying Sharepoint files', { site: siteId, folder: parentId });
         const qs = querystring.stringify(_.pickBy(options));
@@ -38,8 +38,8 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getPreview(fileId, siteId) {
-        siteId = siteId || rootFolderId;
-        
+        siteId = this._validateContainer(siteId);
+
         this.logger.info('Getting Sharepoint file preview', { siteId, fileId });
         return super.getPreview(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/thumbnails`);
     }
@@ -57,7 +57,7 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getFileById(fileId, siteId, options) {
-        siteId = siteId || rootFolderId;
+        siteId = this._validateContainer(siteId);
 
         this.logger.info(`Getting Sharepoint file`, { siteId, fileId });
         return super.getFileById(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}`, options);
@@ -66,6 +66,10 @@ class SharepointClient extends BaseDriveClient {
     getPublicUrl(fileId, siteId) {
         return this.getFileById(fileId, siteId)
             .then(file => file.webUrl);
+    }
+
+    _validateContainer(containerId) {
+        return containerId || rootFolderId;
     }
 }
 

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18 
+const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18
 const {
     logErrorAndReject,
     formatDriveResponse,
@@ -39,7 +39,7 @@ class SharepointClient extends BaseDriveClient {
 
     getPreview(fileId, siteId) {
         siteId = siteId || rootFolderId;
-        
+
         this.logger.info('Getting Sharepoint file preview', { siteId, fileId });
         return super.getPreview(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/thumbnails`);
     }
@@ -66,6 +66,14 @@ class SharepointClient extends BaseDriveClient {
     getPublicUrl(fileId, siteId) {
         return this.getFileById(fileId, siteId)
             .then(file => file.webUrl);
+    }
+
+    shareForEmail(fileId, siteId, email) {
+        return super.shareForEmail(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/invite`, email);
+    }
+
+    unshareFrom(fileId, siteId, permissionId) {
+        return super.unshareFrom(`${ROOT_URL}/sites/${siteId}/drive/items/${fileId}/permissions/${permissionId}`);
     }
 }
 

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18
+const querystring = require('querystring'); // deprecated for node 14-17, will be stable for node 18 
 const {
     logErrorAndReject,
     formatDriveResponse,
@@ -27,8 +27,8 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getFilesFrom(siteId, parentId, options = {}) {
-        parentId = this._validateContainer(parentId);
-        siteId = this._validateContainer(siteId);
+        parentId = parentId || rootFolderId;
+        siteId = siteId || rootFolderId;
 
         this.logger.info('Querying Sharepoint files', { site: siteId, folder: parentId });
         const qs = querystring.stringify(_.pickBy(options));
@@ -38,8 +38,8 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getPreview(fileId, siteId) {
-        siteId = this._validateContainer(siteId);
-
+        siteId = siteId || rootFolderId;
+        
         this.logger.info('Getting Sharepoint file preview', { siteId, fileId });
         return super.getPreview(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/thumbnails`);
     }
@@ -57,7 +57,7 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getFileById(fileId, siteId, options) {
-        siteId = this._validateContainer(siteId);
+        siteId = siteId || rootFolderId;
 
         this.logger.info(`Getting Sharepoint file`, { siteId, fileId });
         return super.getFileById(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}`, options);
@@ -66,20 +66,6 @@ class SharepointClient extends BaseDriveClient {
     getPublicUrl(fileId, siteId) {
         return this.getFileById(fileId, siteId)
             .then(file => file.webUrl);
-    }
-
-    shareTo(fileId, siteId, email) {
-        siteId = this._validateContainer(siteId);
-        return super.shareForEmail(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/invite`, email);
-    }
-
-    unshareFrom(fileId, siteId, permissionId) {
-        siteId = this._validateContainer(siteId);
-        return super.unshareFrom(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/permissions/${permissionId}`);
-    }
-
-    _validateContainer(containerId) {
-        return containerId || rootFolderId;
     }
 }
 

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -27,8 +27,8 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getFilesFrom(siteId, parentId, options = {}) {
-        parentId = parentId || rootFolderId;
-        siteId = siteId || rootFolderId;
+        parentId = this._validateContainer(parentId);
+        siteId = this._validateContainer(siteId);
 
         this.logger.info('Querying Sharepoint files', { site: siteId, folder: parentId });
         const qs = querystring.stringify(_.pickBy(options));
@@ -38,7 +38,7 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getPreview(fileId, siteId) {
-        siteId = siteId || rootFolderId;
+        siteId = this._validateContainer(siteId);
 
         this.logger.info('Getting Sharepoint file preview', { siteId, fileId });
         return super.getPreview(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/thumbnails`);
@@ -57,7 +57,7 @@ class SharepointClient extends BaseDriveClient {
     }
 
     getFileById(fileId, siteId, options) {
-        siteId = siteId || rootFolderId;
+        siteId = this._validateContainer(siteId);
 
         this.logger.info(`Getting Sharepoint file`, { siteId, fileId });
         return super.getFileById(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}`, options);
@@ -68,12 +68,18 @@ class SharepointClient extends BaseDriveClient {
             .then(file => file.webUrl);
     }
 
-    shareForEmail(fileId, siteId, email) {
+    shareTo(fileId, siteId, email) {
+        siteId = this._validateContainer(siteId);
         return super.shareForEmail(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/invite`, email);
     }
 
     unshareFrom(fileId, siteId, permissionId) {
+        siteId = this._validateContainer(siteId);
         return super.unshareFrom(`${ROOT_URL}/sites/${siteId}/drive/items/${fileId}/permissions/${permissionId}`);
+    }
+
+    _validateContainer(containerId) {
+        return containerId || rootFolderId;
     }
 }
 

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -75,7 +75,7 @@ class SharepointClient extends BaseDriveClient {
 
     unshareFrom(fileId, siteId, permissionId) {
         siteId = this._validateContainer(siteId);
-        return super.unshareFrom(`${ROOT_URL}/sites/${siteId}/drive/items/${fileId}/permissions/${permissionId}`);
+        return super.unshareFrom(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/permissions/${permissionId}`);
     }
 
     _validateContainer(containerId) {

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -68,6 +68,41 @@ class SharepointClient extends BaseDriveClient {
             .then(file => file.webUrl);
     }
 
+    /**
+     * Creates sharing link of specified type if it does not already exist
+     * or returns sharing link if link of such a type already exists
+     * @param {string} fileId Sharepoint drive item ID
+     * @param {string} siteId Sharepoint site ID
+     * @returns {Promise<Permission>} https://learn.microsoft.com/en-us/graph/api/resources/permission?view=graph-rest-1.0#properties
+     * @async
+     */
+    createSharingLink(fileId, siteId) {
+        siteId = this._validateContainer(siteId);
+        this.logger.info(`Creating Sharepoint sharing link (or getting if it already exists)`, { siteId, fileId });
+
+        return super.createSharingLink(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/createLink`);
+    }
+
+    /**
+     * Deletes file's permission
+     * @param {string} permissionId Permission ID of Sharepoint drive item (item can have multiple permissions)
+     * @param {string} fileId Sharepoint drive item ID
+     * @param {string} siteId Sharepoint site ID
+     * @returns {Promise<undefined>}
+     * @async
+     */
+    deletePermission(permissionId, fileId, siteId) {
+        siteId = this._validateContainer(siteId);
+        this.logger.info(`Removing Sharepoint file permission`, { siteId, fileId, permissionId });
+
+        return super.deletePermissions(`${this.ROOT_URL}/sites/${siteId}/drive/items/${fileId}/permissions/${permissionId}`);
+    }
+
+    /**
+     * Returns provided containerId or if it falsy value - id of root container
+     * @param {string} containerId Container ID, where container can be drive, site, folder etc.
+     * @returns {string}
+     */
     _validateContainer(containerId) {
         return containerId || rootFolderId;
     }


### PR DESCRIPTION
Task #48 

### Merge after PR #52 

Changes:
- added methods to work with sharing links of drive items;
- reverted `unshareFrom` for onedrive as sharemanager still works with emails but not with permission ids.