### PR TITLE
#59 Extend onedrive's `createFolder` method response

### DIFF
--- a/src/oneDriveClient.js
+++ b/src/oneDriveClient.js
@@ -5,6 +5,7 @@ const { UPLOAD_CONFLICT_RESOLUTION_MODES } = require('./constants');
 const {
     logErrorAndReject,
     formatDriveResponse,
+    formatItemResponse,
     validateAndDefaultTo,
     getParamValue,
 } = require("./util");
@@ -163,9 +164,7 @@ class OneDriveClient extends BaseDriveClient {
 
         return this.graphApi.request(url, 'post', body)
             .catch(logErrorAndReject('Non-200 while trying to create folder', this.logger))
-            .then(data => {
-                return data.id
-            });
+            .then(formatItemResponse);
     }
 
     createFileAndPopulate(fileName, content, folderId = '', useDocx = true) {

--- a/src/util.js
+++ b/src/util.js
@@ -24,12 +24,16 @@ const formatDriveResponse = data => {
     }
     return {
         cursor: skiptoken,
-        items: value.map(file => ({
-            ...file,
-            isFolder: !!file.folder,
-        }))
+        items: value.map(formatItemResponse),
     };
 };
+
+const formatItemResponse = item => {
+    return {
+        ...item,
+        isFolder: !!item.folder,
+    };
+}
 
 const DEFAULT_SCOPES = [
     'offline_access',


### PR DESCRIPTION
Task #59 

BREAKING CHANGE! Onedrive's `createFolder` method now returns `object` instead of `string`.